### PR TITLE
bring i18n back

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'rake'
 
 gem 'bcrypt'
 gem 'dotenv', '~> 2.4'
+gem 'i18n'
 gem 'image_processing'
 gem 'pg'
 gem 'rollbar'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -271,6 +271,7 @@ DEPENDENCIES
   hanami (~> 1.3)
   hanami-model (~> 1.3)
   hanami-webconsole
+  i18n
   image_processing
   pg
   pry-byebug


### PR DESCRIPTION
it was removed by mistake in https://github.com/sausage-sandwich/ruby_sandwich/pull/72/